### PR TITLE
Upgrade app-template from 4.6.2 to 5.0.1

### DIFF
--- a/k8s-apps/0_template/Chart.yaml
+++ b/k8s-apps/0_template/Chart.yaml
@@ -6,4 +6,4 @@ version: 0.1.0
 dependencies:
   - name: app-template
     repository: https://bjw-s-labs.github.io/helm-charts
-    version: 4.6.2
+    version: 5.0.1

--- a/k8s-apps/0_template/values.yaml
+++ b/k8s-apps/0_template/values.yaml
@@ -79,9 +79,10 @@ app-template:
 
   # rawResources:
   #   sablier:
-  #     apiVersion: traefik.io/v1alpha1
-  #     kind: Middleware
-  #     spec:
+  #     enabled: true
+  #     manifest:
+  #       apiVersion: traefik.io/v1alpha1
+  #       kind: Middleware
   #       spec:
   #         plugin:
   #           sablier:

--- a/k8s-apps/anki-sync-server/Chart.yaml
+++ b/k8s-apps/anki-sync-server/Chart.yaml
@@ -6,4 +6,4 @@ version: 0.1.0
 dependencies:
   - name: app-template
     repository: https://bjw-s-labs.github.io/helm-charts
-    version: 4.6.2
+    version: 5.0.1

--- a/k8s-apps/anki-sync-server/values.yaml
+++ b/k8s-apps/anki-sync-server/values.yaml
@@ -79,10 +79,11 @@ app-template:
 
   rawResources:
     sablier:
-      apiVersion: traefik.io/v1alpha1
-      kind: Middleware
+      enabled: true
       forceRename: sablier
-      spec:
+      manifest:
+        apiVersion: traefik.io/v1alpha1
+        kind: Middleware
         spec:
           plugin:
             sablier:

--- a/k8s-apps/anubis/Chart.yaml
+++ b/k8s-apps/anubis/Chart.yaml
@@ -6,4 +6,4 @@ version: 0.1.0
 dependencies:
   - name: app-template
     repository: https://bjw-s-labs.github.io/helm-charts
-    version: 4.6.2
+    version: 5.0.1

--- a/k8s-apps/anubis/values.yaml
+++ b/k8s-apps/anubis/values.yaml
@@ -81,9 +81,10 @@ app-template:
 
   rawResources:
     anubis:
-      apiVersion: traefik.io/v1alpha1
-      kind: Middleware
-      spec:
+      enabled: true
+      manifest:
+        apiVersion: traefik.io/v1alpha1
+        kind: Middleware
         spec:
           forwardAuth:
             address: http://anubis.anubis.svc.cluster.local:8080/.within.website/x/cmd/anubis/api/check

--- a/k8s-apps/arr-stack/Chart.yaml
+++ b/k8s-apps/arr-stack/Chart.yaml
@@ -6,7 +6,7 @@ version: 0.1.0
 dependencies:
   - name: app-template
     repository: https://bjw-s-labs.github.io/helm-charts
-    version: 4.6.2
+    version: 5.0.1
   - name: cluster
     alias: cnpg-cluster-jellystat
     repository: https://cloudnative-pg.github.io/charts

--- a/k8s-apps/attic/Chart.yaml
+++ b/k8s-apps/attic/Chart.yaml
@@ -6,7 +6,7 @@ version: 0.1.0
 dependencies:
   - name: app-template
     repository: https://bjw-s-labs.github.io/helm-charts
-    version: 4.6.2
+    version: 5.0.1
   - name: cluster
     alias: cnpg-cluster
     repository: https://cloudnative-pg.github.io/charts

--- a/k8s-apps/audiobookshelf/Chart.yaml
+++ b/k8s-apps/audiobookshelf/Chart.yaml
@@ -6,4 +6,4 @@ version: 0.1.0
 dependencies:
   - name: app-template
     repository: https://bjw-s-labs.github.io/helm-charts
-    version: 4.6.2
+    version: 5.0.1

--- a/k8s-apps/audiobookshelf/values.yaml
+++ b/k8s-apps/audiobookshelf/values.yaml
@@ -305,12 +305,14 @@ app-template:
 
   rawResources:
     webdav-password:
-      apiVersion: external-secrets.io/v1
-      kind: ExternalSecret
+      enabled: true
       forceRename: "{{ .Release.Name }}-webdav-password"
-      annotations:
-        argocd.argoproj.io/sync-options: ServerSideApply=true
-      spec:
+      manifest:
+        apiVersion: external-secrets.io/v1
+        kind: ExternalSecret
+        metadata:
+          annotations:
+            argocd.argoproj.io/sync-options: ServerSideApply=true
         spec:
           refreshInterval: "0"
           target:
@@ -323,10 +325,11 @@ app-template:
                   kind: ClusterGenerator
                   name: short-password
     strip-prefix:
-      apiVersion: traefik.io/v1alpha1
-      kind: Middleware
+      enabled: true
       forceRename: "strip-dav-prefix"
-      spec:
+      manifest:
+        apiVersion: traefik.io/v1alpha1
+        kind: Middleware
         spec:
           stripPrefix:
             prefixes:

--- a/k8s-apps/calibre-web/Chart.yaml
+++ b/k8s-apps/calibre-web/Chart.yaml
@@ -6,4 +6,4 @@ version: 0.1.0
 dependencies:
   - name: app-template
     repository: https://bjw-s-labs.github.io/helm-charts
-    version: 4.6.2
+    version: 5.0.1

--- a/k8s-apps/changedetection/Chart.yaml
+++ b/k8s-apps/changedetection/Chart.yaml
@@ -9,4 +9,4 @@ dependencies:
     version: 1.94.0
   - name: app-template
     repository: https://bjw-s-labs.github.io/helm-charts
-    version: 4.6.2
+    version: 5.0.1

--- a/k8s-apps/convertx/Chart.yaml
+++ b/k8s-apps/convertx/Chart.yaml
@@ -6,4 +6,4 @@ version: 0.1.0
 dependencies:
   - name: app-template
     repository: https://bjw-s-labs.github.io/helm-charts
-    version: 4.6.2
+    version: 5.0.1

--- a/k8s-apps/gitea/Chart.yaml
+++ b/k8s-apps/gitea/Chart.yaml
@@ -17,4 +17,4 @@ dependencies:
   - name: app-template
     alias: gitea-mirror
     repository: https://bjw-s-labs.github.io/helm-charts
-    version: 4.6.2
+    version: 5.0.1

--- a/k8s-apps/go-healthcheck/Chart.yaml
+++ b/k8s-apps/go-healthcheck/Chart.yaml
@@ -6,4 +6,4 @@ version: 0.1.0
 dependencies:
   - name: app-template
     repository: https://bjw-s-labs.github.io/helm-charts
-    version: 4.6.2
+    version: 5.0.1

--- a/k8s-apps/httpbin/Chart.yaml
+++ b/k8s-apps/httpbin/Chart.yaml
@@ -6,4 +6,4 @@ version: 0.1.0
 dependencies:
   - name: app-template
     repository: https://bjw-s-labs.github.io/helm-charts
-    version: 4.6.2
+    version: 5.0.1

--- a/k8s-apps/it-tools/Chart.yaml
+++ b/k8s-apps/it-tools/Chart.yaml
@@ -6,4 +6,4 @@ version: 0.1.0
 dependencies:
   - name: app-template
     repository: https://bjw-s-labs.github.io/helm-charts
-    version: 4.6.2
+    version: 5.0.1

--- a/k8s-apps/kube-prometheus-stack/Chart.yaml
+++ b/k8s-apps/kube-prometheus-stack/Chart.yaml
@@ -10,4 +10,4 @@ dependencies:
   - name: app-template
     alias: grafana-mcp-server
     repository: https://bjw-s-labs.github.io/helm-charts
-    version: 4.6.2
+    version: 5.0.1

--- a/k8s-apps/kube-prometheus-stack/values.yaml
+++ b/k8s-apps/kube-prometheus-stack/values.yaml
@@ -395,9 +395,10 @@ grafana-mcp-server:
 
   rawResources:
     grafana-mcp-credentials:
-      apiVersion: external-secrets.io/v1
-      kind: ExternalSecret
-      spec:
+      enabled: true
+      manifest:
+        apiVersion: external-secrets.io/v1
+        kind: ExternalSecret
         spec:
           secretStoreRef:
             kind: ClusterSecretStore
@@ -413,18 +414,20 @@ grafana-mcp-server:
                 metadataPolicy: None
                 nullBytePolicy: Ignore
     grafana-mcp-auth-middleware:
-      apiVersion: traefik.io/v1alpha1
-      kind: Middleware
+      enabled: true
       forceRename: grafana-mcp-auth
-      spec:
+      manifest:
+        apiVersion: traefik.io/v1alpha1
+        kind: Middleware
         spec:
           basicAuth:
             secret: grafana-mcp-auth
     mcp-auth-secret:
-      apiVersion: external-secrets.io/v1
-      kind: ExternalSecret
+      enabled: true
       forceRename: grafana-mcp-auth
-      spec:
+      manifest:
+        apiVersion: external-secrets.io/v1
+        kind: ExternalSecret
         spec:
           refreshInterval: "0"
           target:

--- a/k8s-apps/lastfm-scrobble-deduplicator/Chart.yaml
+++ b/k8s-apps/lastfm-scrobble-deduplicator/Chart.yaml
@@ -6,4 +6,4 @@ version: 0.1.0
 dependencies:
   - name: app-template
     repository: https://bjw-s-labs.github.io/helm-charts
-    version: 4.6.2
+    version: 5.0.1

--- a/k8s-apps/microbin/Chart.yaml
+++ b/k8s-apps/microbin/Chart.yaml
@@ -6,4 +6,4 @@ version: 0.1.0
 dependencies:
   - name: app-template
     repository: https://bjw-s-labs.github.io/helm-charts
-    version: 4.6.2
+    version: 5.0.1

--- a/k8s-apps/niks3/Chart.yaml
+++ b/k8s-apps/niks3/Chart.yaml
@@ -6,7 +6,7 @@ version: 0.1.0
 dependencies:
   - name: app-template
     repository: https://bjw-s-labs.github.io/helm-charts
-    version: 4.6.2
+    version: 5.0.1
   - name: cluster
     alias: cnpg-cluster
     repository: https://cloudnative-pg.github.io/charts

--- a/k8s-apps/niks3/values.yaml
+++ b/k8s-apps/niks3/values.yaml
@@ -163,9 +163,10 @@ app-template:
 
   rawResources:
     api-token:
-      apiVersion: external-secrets.io/v1
-      kind: ExternalSecret
-      spec:
+      enabled: true
+      manifest:
+        apiVersion: external-secrets.io/v1
+        kind: ExternalSecret
         spec:
           secretStoreRef:
             kind: ClusterSecretStore
@@ -177,9 +178,10 @@ app-template:
             - extract:
                 key: niks3/api-token
     signing-key:
-      apiVersion: external-secrets.io/v1
-      kind: ExternalSecret
-      spec:
+      enabled: true
+      manifest:
+        apiVersion: external-secrets.io/v1
+        kind: ExternalSecret
         spec:
           secretStoreRef:
             kind: ClusterSecretStore
@@ -191,9 +193,10 @@ app-template:
             - extract:
                 key: niks3/signing-key
     versity:
-      apiVersion: external-secrets.io/v1
-      kind: ExternalSecret
-      spec:
+      enabled: true
+      manifest:
+        apiVersion: external-secrets.io/v1
+        kind: ExternalSecret
         spec:
           secretStoreRef:
             kind: ClusterSecretStore

--- a/k8s-apps/opencloud/Chart.yaml
+++ b/k8s-apps/opencloud/Chart.yaml
@@ -6,4 +6,4 @@ version: 0.1.0
 dependencies:
   - name: app-template
     repository: https://bjw-s-labs.github.io/helm-charts
-    version: 4.6.2
+    version: 5.0.1

--- a/k8s-apps/paperless-ngx/Chart.yaml
+++ b/k8s-apps/paperless-ngx/Chart.yaml
@@ -6,7 +6,7 @@ version: 0.1.0
 dependencies:
   - name: app-template
     repository: https://bjw-s-labs.github.io/helm-charts
-    version: 4.6.2
+    version: 5.0.1
   - name: valkey
     repository: https://valkey.io/valkey-helm/
     version: 0.9.4

--- a/k8s-apps/satisfactory-server/Chart.yaml
+++ b/k8s-apps/satisfactory-server/Chart.yaml
@@ -6,7 +6,7 @@ version: 0.1.0
 dependencies:
   - name: app-template
     repository: https://bjw-s-labs.github.io/helm-charts
-    version: 4.6.2
+    version: 5.0.1
   - name: cluster
     alias: cnpg-cluster-pg17
     repository: https://cloudnative-pg.github.io/charts

--- a/k8s-apps/tts9000/Chart.yaml
+++ b/k8s-apps/tts9000/Chart.yaml
@@ -6,4 +6,4 @@ version: 0.1.0
 dependencies:
   - name: app-template
     repository: https://bjw-s-labs.github.io/helm-charts
-    version: 4.6.2
+    version: 5.0.1

--- a/k8s-apps/tts9000/values.yaml
+++ b/k8s-apps/tts9000/values.yaml
@@ -70,12 +70,14 @@ app-template:
 
   rawResources:
     credentials:
-      apiVersion: external-secrets.io/v1
-      kind: ExternalSecret
+      enabled: true
       forceRename: "credentials"
-      annotations:
-        argocd.argoproj.io/sync-options: ServerSideApply=true
-      spec:
+      manifest:
+        apiVersion: external-secrets.io/v1
+        kind: ExternalSecret
+        metadata:
+          annotations:
+            argocd.argoproj.io/sync-options: ServerSideApply=true
         spec:
           secretStoreRef:
             kind: ClusterSecretStore

--- a/k8s-apps/versity-gw/Chart.yaml
+++ b/k8s-apps/versity-gw/Chart.yaml
@@ -6,4 +6,4 @@ version: 0.1.0
 dependencies:
   - name: app-template
     repository: https://bjw-s-labs.github.io/helm-charts
-    version: 4.6.2
+    version: 5.0.1

--- a/k8s-apps/versity-gw/values.yaml
+++ b/k8s-apps/versity-gw/values.yaml
@@ -279,10 +279,11 @@ app-template:
 
   rawResources:
     sablier:
-      apiVersion: traefik.io/v1alpha1
-      kind: Middleware
+      enabled: true
       forceRename: sablier
-      spec:
+      manifest:
+        apiVersion: traefik.io/v1alpha1
+        kind: Middleware
         spec:
           plugin:
             sablier:


### PR DESCRIPTION
- Bump app-template version in all Chart.yaml files
- Fix rawResources structure for v5 compatibility:
  - Add 'manifest:' wrapper around Kubernetes manifests
  - Move annotations under metadata.annotations
  - Remove nested spec: spec: structure
- Update 0_template with new rawResources example

Breaking changes addressed:
- rawResources restructure (manifest wrapper)
- ServiceAccount now auto-created by default
- automountServiceAccountToken now defaults to false

Generated by Mistral Vibe.