### PR TITLE
feat(arr-stack): alert on qbittorrent wireguard tunnel down

### DIFF
--- a/k8s-apps/arr-stack/templates/tunnel-monitor.yaml
+++ b/k8s-apps/arr-stack/templates/tunnel-monitor.yaml
@@ -1,0 +1,57 @@
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: qbittorrent-tunnel
+  labels:
+    app.kubernetes.io/name: qbittorrent-tunnel
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/instance: {{ .Release.Name }}
+      app.kubernetes.io/service: {{ .Release.Name }}-qbittorrent
+  endpoints:
+    - port: probe
+      path: /probe
+      interval: 60s
+      scrapeTimeout: 10s
+      params:
+        module:
+          - icmp_tunnel
+        target:
+          - 192.168.2.1
+      metricRelabelings:
+        - sourceLabels: [__name__]
+          targetLabel: tunnel
+          replacement: qbittorrent-wg
+---
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: qbittorrent-tunnel
+spec:
+  groups:
+    - name: wireguard-tunnel
+      rules:
+        - alert: WireguardTunnelDown
+          # probe_success from the in-pod blackbox sidecar pinging the wg peer.
+          expr: probe_success{service="{{ .Release.Name }}-qbittorrent"} == 0
+          for: 2m
+          labels:
+            severity: critical
+          annotations:
+            summary: qBittorrent wireguard tunnel down
+            description: >-
+              ICMP probe to the wireguard peer 192.168.2.1 through gluetun has
+              failed for over 2 minutes. The tunnel to free-oracle-arm-1 is
+              likely down.
+        - alert: WireguardTunnelProbeMissing
+          # Sidecar or scrape gone: no probe data at all.
+          expr: absent(probe_success{service="{{ .Release.Name }}-qbittorrent"})
+          for: 10m
+          labels:
+            severity: warning
+          annotations:
+            summary: qBittorrent wireguard tunnel probe missing
+            description: >-
+              No probe_success metric from the qbittorrent tunnel monitor for
+              over 10 minutes. The sidecar or ServiceMonitor may be broken.

--- a/k8s-apps/arr-stack/values.yaml
+++ b/k8s-apps/arr-stack/values.yaml
@@ -563,6 +563,37 @@ app-template:
               enabled: true
               type: HTTP
 
+        # Pings the wireguard peer through gluetun's netns so Prometheus can
+        # detect a dead tunnel even when the pod itself stays healthy.
+        tunnel-monitor:
+          image:
+            repository: quay.io/prometheus/blackbox-exporter
+            tag: v0.28.0@sha256:e753ff9f3fc458d02cca5eddab5a77e1c175eee484a8925ac7d524f04366c2fc
+          args:
+            - --config.file=/config/blackbox.yml
+          ports:
+            - name: probe
+              containerPort: 9115
+          securityContext:
+            capabilities:
+              add:
+                - NET_RAW
+          probes:
+            liveness:
+              enabled: true
+              custom: true
+              spec:
+                httpGet:
+                  port: 9115
+                  path: /-/healthy
+            readiness:
+              enabled: true
+              custom: true
+              spec:
+                httpGet:
+                  port: 9115
+                  path: /-/healthy
+
     filebrowser-quantum:
       type: deployment
       strategy: Recreate
@@ -771,6 +802,8 @@ app-template:
       ports:
         http:
           port: 8080
+        probe:
+          port: 9115
     filebrowser-quantum:
       controller: filebrowser-quantum
       type: ClusterIP
@@ -1262,6 +1295,15 @@ app-template:
             - path: /app/repos
               subPath: configarr-repos
 
+    tunnel-monitor-config:
+      type: configMap
+      identifier: tunnel-monitor-config
+      advancedMounts:
+        qbittorrent:
+          tunnel-monitor:
+            - path: /config/blackbox.yml
+              subPath: blackbox.yml
+
     configarr-config:
       type: configMap
       identifier: configarr-config
@@ -1367,6 +1409,16 @@ app-template:
               subPath: run-rangemusique.sh
 
   configMaps:
+    tunnel-monitor-config:
+      data:
+        blackbox.yml: |
+          modules:
+            icmp_tunnel:
+              prober: icmp
+              timeout: 5s
+              icmp:
+                preferred_ip_protocol: ip4
+
     configarr-config:
       data:
         config.yml: |


### PR DESCRIPTION
## What

Alert to Telegram when the qBittorrent → `free-oracle-arm-1` wireguard tunnel is down.

Motivated by a real incident where the tunnel was dead (`wg` empty on the VM) but the qBittorrent pod stayed healthy — pod health and gluetun's `/v1/vpn/status` both lied. The only reliable signal is a real packet crossing the tunnel.

## How

- **Sidecar** `tunnel-monitor` (blackbox-exporter `v0.28.0`, digest-pinned) in the qBittorrent pod. It shares the pod netns with gluetun, so its ICMP goes through `wg0`. Granted `NET_RAW`.
- **ConfigMap** `tunnel-monitor-config`: blackbox `icmp_tunnel` module.
- **Service**: added port `9115`.
- **ServiceMonitor** `qbittorrent-tunnel`: scrapes `/probe?target=192.168.2.1&module=icmp_tunnel` every 60s.
- **PrometheusRule** `qbittorrent-tunnel`:
  - `WireguardTunnelDown` — `probe_success == 0` for 2m, severity `critical`.
  - `WireguardTunnelProbeMissing` — probe metric absent for 10m, severity `warning` (catches a broken sidecar/scrape).

## No kube-prometheus-stack change needed

Prometheus already watches all ServiceMonitors + PrometheusRules cluster-wide, and Alertmanager already routes `critical`/`warning` to Telegram. `WireguardTunnelDown` is not in the `empty` receiver matcher list, so it reaches Telegram automatically.

## Verify after deploy

Confirm `probe_success` carries the label `service="arr-stack-qbittorrent"` (the Prometheus operator injects it). If not, the rule expr needs switching to `namespace`/`pod` labels.
