### PR TITLE
feat(arr-stack): alert on qbittorrent wireguard tunnel down

### DIFF
--- a/k8s-apps/arr-stack/templates/tunnel-monitor.yaml
+++ b/k8s-apps/arr-stack/templates/tunnel-monitor.yaml
@@ -1,0 +1,57 @@
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: qbittorrent-tunnel
+  labels:
+    app.kubernetes.io/name: qbittorrent-tunnel
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/instance: {{ .Release.Name }}
+      app.kubernetes.io/service: {{ .Release.Name }}-qbittorrent
+  endpoints:
+    - port: probe
+      path: /probe
+      interval: 60s
+      scrapeTimeout: 10s
+      params:
+        module:
+          - icmp_tunnel
+        target:
+          - 192.168.2.1
+      metricRelabelings:
+        - sourceLabels: [__name__]
+          targetLabel: tunnel
+          replacement: qbittorrent-wg
+---
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: qbittorrent-tunnel
+spec:
+  groups:
+    - name: wireguard-tunnel
+      rules:
+        - alert: WireguardTunnelDown
+          # probe_success from the in-pod blackbox sidecar pinging the wg peer.
+          expr: probe_success{service="{{ .Release.Name }}-qbittorrent"} == 0
+          for: 2m
+          labels:
+            severity: critical
+          annotations:
+            summary: qBittorrent wireguard tunnel down
+            description: >-
+              ICMP probe to the wireguard peer 192.168.2.1 through gluetun has
+              failed for over 2 minutes. The tunnel to free-oracle-arm-1 is
+              likely down.
+        - alert: WireguardTunnelProbeMissing
+          # Sidecar or scrape gone: no probe data at all.
+          expr: absent(probe_success{service="{{ .Release.Name }}-qbittorrent"})
+          for: 10m
+          labels:
+            severity: warning
+          annotations:
+            summary: qBittorrent wireguard tunnel probe missing
+            description: >-
+              No probe_success metric from the qbittorrent tunnel monitor for
+              over 10 minutes. The sidecar or ServiceMonitor may be broken.

--- a/k8s-apps/arr-stack/values.yaml
+++ b/k8s-apps/arr-stack/values.yaml
@@ -563,6 +563,41 @@ app-template:
               enabled: true
               type: HTTP
 
+        # Pings the wireguard peer through gluetun's netns so Prometheus can
+        # detect a dead tunnel even when the pod itself stays healthy.
+        tunnel-monitor:
+          image:
+            repository: quay.io/prometheus/blackbox-exporter
+            tag: v0.28.0@sha256:e753ff9f3fc458d02cca5eddab5a77e1c175eee484a8925ac7d524f04366c2fc
+          args:
+            - --config.file=/config/blackbox.yml
+          ports:
+            - name: probe
+              containerPort: 9115
+          securityContext:
+            # Root + NET_RAW is required for blackbox's raw ICMP socket;
+            # a non-root UID drops the added capability from the effective set.
+            runAsUser: 0
+            runAsGroup: 0
+            capabilities:
+              add:
+                - NET_RAW
+          probes:
+            liveness:
+              enabled: true
+              custom: true
+              spec:
+                httpGet:
+                  port: 9115
+                  path: /-/healthy
+            readiness:
+              enabled: true
+              custom: true
+              spec:
+                httpGet:
+                  port: 9115
+                  path: /-/healthy
+
     filebrowser-quantum:
       type: deployment
       strategy: Recreate
@@ -771,6 +806,8 @@ app-template:
       ports:
         http:
           port: 8080
+        probe:
+          port: 9115
     filebrowser-quantum:
       controller: filebrowser-quantum
       type: ClusterIP
@@ -1262,6 +1299,15 @@ app-template:
             - path: /app/repos
               subPath: configarr-repos
 
+    tunnel-monitor-config:
+      type: configMap
+      identifier: tunnel-monitor-config
+      advancedMounts:
+        qbittorrent:
+          tunnel-monitor:
+            - path: /config/blackbox.yml
+              subPath: blackbox.yml
+
     configarr-config:
       type: configMap
       identifier: configarr-config
@@ -1367,6 +1413,16 @@ app-template:
               subPath: run-rangemusique.sh
 
   configMaps:
+    tunnel-monitor-config:
+      data:
+        blackbox.yml: |
+          modules:
+            icmp_tunnel:
+              prober: icmp
+              timeout: 5s
+              icmp:
+                preferred_ip_protocol: ip4
+
     configarr-config:
       data:
         config.yml: |


### PR DESCRIPTION
Add a blackbox-exporter sidecar to the qbittorrent pod that pings the wireguard peer (192.168.2.1) through gluetun's netns. A ServiceMonitor scrapes it and a PrometheusRule fires WireguardTunnelDown when the probe fails, catching dead-handshake cases where the pod stays healthy.