### PR TITLE
fix(lastfm-dedup): add startup probe to chromium sidecar

### DIFF
--- a/k8s-apps/lastfm-scrobble-deduplicator/values.yaml
+++ b/k8s-apps/lastfm-scrobble-deduplicator/values.yaml
@@ -54,11 +54,6 @@ app-template:
             TIMEOUT: 600000
           restartPolicy: Always
           probes:
-            # Startup probe gates the main app container: with a native sidecar
-            # (restartPolicy: Always) Kubernetes only waits for the sidecar to be
-            # *started* before running the app. Without this, the app races ahead
-            # and dials ws://localhost:3000 before browserless binds the port,
-            # causing "connection refused".
             startup:
               enabled: true
               custom: true

--- a/k8s-apps/lastfm-scrobble-deduplicator/values.yaml
+++ b/k8s-apps/lastfm-scrobble-deduplicator/values.yaml
@@ -54,6 +54,20 @@ app-template:
             TIMEOUT: 600000
           restartPolicy: Always
           probes:
+            # Startup probe gates the main app container: with a native sidecar
+            # (restartPolicy: Always) Kubernetes only waits for the sidecar to be
+            # *started* before running the app. Without this, the app races ahead
+            # and dials ws://localhost:3000 before browserless binds the port,
+            # causing "connection refused".
+            startup:
+              enabled: true
+              custom: true
+              spec:
+                httpGet:
+                  port: http
+                  path: /active?token=local
+                failureThreshold: 30
+                periodSeconds: 2
             liveness:
               enabled: true
               custom: true


### PR DESCRIPTION
The app races ahead and dials ws://localhost:3000 before browserless binds the port, causing 'connection refused'. A native sidecar (restartPolicy: Always) only gates the main container on the sidecar being *started*, which a startup probe defines. Add an HTTP startup probe on /active so Kubernetes holds the app until the browser is up.