### PR TITLE
ci(deployed-apps): only run on push to main

### DIFF
--- a/.github/workflows/update-deployed-apps.yaml
+++ b/.github/workflows/update-deployed-apps.yaml
@@ -2,6 +2,8 @@ name: Update deployed apps table
 
 on:
   push:
+    branches:
+      - main
     paths:
       - argocd-apps/applicationset.yaml
       - k8s-apps/**


### PR DESCRIPTION
## Why

Investigated all failing Actions with `gh run list --status failure`. **36 of 40** recent failures come from this one workflow, all on renovate branches.

Root cause (from `--log-failed`):
```
fatal: couldn't find remote ref renovate/changedetection-io-1.x
git fetch --no-tags --depth=100 origin main renovate/... failed with exit code 128
```

The workflow triggers on `push` to **any** branch. Renovate pushes a branch, then deletes it (rebase / autoclose) before the run's `dorny/paths-filter` step can `git fetch` it. The ref is gone, `paths-filter` exits 128, the job goes red.

## Fix

Scope the `push` trigger to `main`. The deployed-apps table (README) is only ever committed to `main`, so running on ephemeral renovate branches was pure noise. Removes the race and the 36 recurring failures. `workflow_dispatch` still available for manual runs.

Validated with `actionlint`: clean.