### PR TITLE
fix(image-build): add Replace=true sync option to Job template

### DIFF
--- a/charts/image-build/templates/job.yaml
+++ b/charts/image-build/templates/job.yaml
@@ -11,6 +11,8 @@ metadata:
     app.kubernetes.io/managed-by: image-build
     image-build/image: {{ .Values.image | quote }}
     image-build/tag: {{ .Values.tag | quote }}
+  annotations:
+    argocd.argoproj.io/sync-options: Replace=true
 spec:
   backoffLimit: {{ .Values.backoffLimit }}
   ttlSecondsAfterFinished: {{ .Values.ttlSecondsAfterFinished }}


### PR DESCRIPTION
## Problem

`argocd/build-hello` (generated by the `k8s-apps/image-builds` ApplicationSet) is stuck `OutOfSync` with a `SyncError`:

```
Job.batch "build-hello-v1" is invalid: spec.template: ... field is immutable (retried 5 times)
```

`argocd app diff build-hello` shows the perma-diff:

```
<   image: gcr.io/kaniko-project/executor:v1.23.2          (live)
>   image: gcr.io/kaniko-project/executor:v1.24.0@sha256:4e7a52...  (git)
```

## Root cause

Commit `208f969d` bumped the chart's `kanikoImage` from v1.23.2 to v1.24.0. But `build-hello-v1` is a **completed Job**, and a Job's `spec.template` is immutable. ArgoCD's automated self-heal keeps trying to patch the live Job image and fails every sync, so the diff can never converge.

## Fix

Add the `argocd.argoproj.io/sync-options: Replace=true` annotation to the Job template in `charts/image-build/templates/job.yaml`. With this, ArgoCD will delete and recreate the Job on a spec diff instead of patching an immutable field. Future `kanikoImage` bumps will cleanly trigger a rebuild rather than getting stuck.

## Verification

- `helm template` renders the Job with the annotation in place.
- No other files changed.

## Notes

- Once merged, ArgoCD self-heal will delete and recreate `build-hello-v1` with kaniko v1.24.0, re-running the build of `hello:v1`. This is expected/idempotent.
- Same behavior will apply to all other apps generated by the image-build ApplicationSet.

Generated by Mistral Vibe.