### PR TITLE
gitea: replace gitea-mirror app with native mirror reconciler

### DIFF
--- a/image-builds/gitea-mirror-sync/Dockerfile
+++ b/image-builds/gitea-mirror-sync/Dockerfile
@@ -1,0 +1,13 @@
+# Build stage: Kaniko clones the repo into a scratch context and runs this
+# Dockerfile, so the source tree is available. We compile the Go binary with
+# CGO disabled for a static distroless-friendly binary.
+FROM golang:1.26-alpine AS build
+WORKDIR /src
+COPY go.mod ./
+RUN go mod download
+COPY . .
+RUN CGO_ENABLED=0 GOOS=linux go build -trimpath -ldflags="-s -w" -o /out/gitea-mirror-sync .
+
+FROM gcr.io/distroless/static-debian12:nonroot
+COPY --from=build /out/gitea-mirror-sync /usr/local/bin/gitea-mirror-sync
+ENTRYPOINT ["/usr/local/bin/gitea-mirror-sync"]

--- a/image-builds/gitea-mirror-sync/build.yaml
+++ b/image-builds/gitea-mirror-sync/build.yaml
@@ -1,0 +1,2 @@
+image: gitea-mirror-sync
+tag: v1

--- a/image-builds/gitea-mirror-sync/go.mod
+++ b/image-builds/gitea-mirror-sync/go.mod
@@ -1,0 +1,5 @@
+module github.com/cterence/homelab-gitops/image-builds/gitea-mirror-sync
+
+go 1.26
+
+require gopkg.in/yaml.v3 v3.0.1

--- a/image-builds/gitea-mirror-sync/go.sum
+++ b/image-builds/gitea-mirror-sync/go.sum
@@ -1,0 +1,4 @@
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/image-builds/gitea-mirror-sync/main.go
+++ b/image-builds/gitea-mirror-sync/main.go
@@ -1,0 +1,329 @@
+// gitea-mirror-sync reconciles a declarative list of git mirrors against a
+// running Gitea instance. It creates missing mirrors, updates settings on
+// existing ones, and prunes mirrors that are no longer in the config.
+package main
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"os"
+	"strings"
+	"time"
+
+	"gopkg.in/yaml.v3"
+)
+
+// Config is the YAML document mounted into the reconciler.
+type Config struct {
+	Mirrors []Mirror `yaml:"mirrors"`
+}
+
+// Mirror is a single desired mirror entry.
+type Mirror struct {
+	Owner          string `yaml:"owner"          json:"owner"`
+	Name           string `yaml:"name"           json:"name"`
+	CloneAddr      string `yaml:"clone_addr"     json:"clone_addr"`
+	MirrorInterval string `yaml:"mirror_interval" json:"mirror_interval,omitempty"`
+	Private        bool   `yaml:"private"        json:"private"`
+	Wiki           bool   `yaml:"wiki"           json:"wiki"`
+}
+
+// repo is the subset of Gitea's repository response that we use.
+type repo struct {
+	Name     string `json:"name"`
+	FullName string `json:"full_name"`
+	Mirror   bool   `json:"mirror"`
+	Private  bool   `json:"private"`
+	Owner    struct {
+		Name string `json:"login"`
+	} `json:"owner"`
+}
+
+type client struct {
+	baseURL string
+	user    string
+	pass    string
+	http    *http.Client
+}
+
+func newClient(baseURL, user, pass string) *client {
+	return &client{
+		baseURL: strings.TrimRight(baseURL, "/"),
+		user:    user,
+		pass:    pass,
+		http:    &http.Client{Timeout: 30 * time.Second},
+	}
+}
+
+func (c *client) do(ctx context.Context, method, path string, body any) (*http.Response, error) {
+	var r io.Reader
+	if body != nil {
+		buf, err := json.Marshal(body)
+		if err != nil {
+			return nil, fmt.Errorf("marshal body: %w", err)
+		}
+		r = bytes.NewReader(buf)
+	}
+	req, err := http.NewRequestWithContext(ctx, method, c.baseURL+path, r)
+	if err != nil {
+		return nil, err
+	}
+	req.SetBasicAuth(c.user, c.pass)
+	if body != nil {
+		req.Header.Set("Content-Type", "application/json")
+	}
+	req.Header.Set("Accept", "application/json")
+	return c.http.Do(req)
+}
+
+// getRepo returns the repo if it exists, nil on 404.
+func (c *client) getRepo(ctx context.Context, owner, name string) (*repo, error) {
+	resp, err := c.do(ctx, http.MethodGet, fmt.Sprintf("/api/v1/repos/%s/%s", owner, name), nil)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	switch {
+	case resp.StatusCode == http.StatusNotFound:
+		return nil, nil
+	case resp.StatusCode == http.StatusOK:
+		var r repo
+		if err := json.NewDecoder(resp.Body).Decode(&r); err != nil {
+			return nil, fmt.Errorf("decode repo: %w", err)
+		}
+		return &r, nil
+	default:
+		return nil, fmt.Errorf("GET repo: %s", bodyText(resp))
+	}
+}
+
+// migrate creates a new mirror via /repos/migrate.
+func (c *client) migrate(ctx context.Context, m Mirror) error {
+	payload := map[string]any{
+		"clone_addr": m.CloneAddr,
+		"repo_owner": m.Owner,
+		"repo_name":  m.Name,
+		"mirror":     true,
+		"private":    m.Private,
+		"wiki":       m.Wiki,
+	}
+	if m.MirrorInterval != "" {
+		payload["mirror_interval"] = m.MirrorInterval
+	}
+	resp, err := c.do(ctx, http.MethodPost, "/api/v1/repos/migrate", payload)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode >= 400 {
+		return fmt.Errorf("migrate %s/%s: %s", m.Owner, m.Name, bodyText(resp))
+	}
+	return nil
+}
+
+// updateRepo patches mirror_interval / private on an existing mirror.
+func (c *client) updateRepo(ctx context.Context, r *repo, m Mirror) error {
+	payload := map[string]any{
+		"private": m.Private,
+	}
+	if m.MirrorInterval != "" {
+		payload["mirror_interval"] = m.MirrorInterval
+	}
+	resp, err := c.do(ctx, http.MethodPatch, fmt.Sprintf("/api/v1/repos/%s/%s", m.Owner, m.Name), payload)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode >= 400 {
+		return fmt.Errorf("patch %s/%s: %s", m.Owner, m.Name, bodyText(resp))
+	}
+	return nil
+}
+
+// listRepos returns all repos owned by owner that the token can see.
+func (c *client) listRepos(ctx context.Context, owner string) ([]repo, error) {
+	var out []repo
+	page := 1
+	for {
+		path := fmt.Sprintf("/api/v1/repos/search?owner=%s&limit=50&page=%d", url.QueryEscape(owner), page)
+		resp, err := c.do(ctx, http.MethodGet, path, nil)
+		if err != nil {
+			return nil, err
+		}
+		if resp.StatusCode >= 400 {
+			resp.Body.Close()
+			return nil, fmt.Errorf("search repos for %s: %s", owner, resp.Status)
+		}
+		var pageResp struct {
+			Data []repo `json:"data"`
+			Ok   bool   `json:"ok"`
+		}
+		if err := json.NewDecoder(resp.Body).Decode(&pageResp); err != nil {
+			resp.Body.Close()
+			return nil, fmt.Errorf("decode search: %w", err)
+		}
+		resp.Body.Close()
+		out = append(out, pageResp.Data...)
+		if len(pageResp.Data) < 50 {
+			break
+		}
+		page++
+	}
+	// /repos/search returns matches across all owners when owner filter is
+	// applied loosely; filter client-side to be safe.
+	var filtered []repo
+	for _, r := range out {
+		if r.Owner.Name == owner {
+			filtered = append(filtered, r)
+		}
+	}
+	return filtered, nil
+}
+
+func (c *client) deleteRepo(ctx context.Context, owner, name string) error {
+	resp, err := c.do(ctx, http.MethodDelete, fmt.Sprintf("/api/v1/repos/%s/%s", owner, name), nil)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode >= 400 && resp.StatusCode != http.StatusNotFound {
+		return fmt.Errorf("delete %s/%s: %s", owner, name, bodyText(resp))
+	}
+	return nil
+}
+
+func bodyText(resp *http.Response) string {
+	b, _ := io.ReadAll(resp.Body)
+	return resp.Status + ": " + string(b)
+}
+
+func loadConfig(path string) (*Config, error) {
+	b, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("read config: %w", err)
+	}
+	var cfg Config
+	if err := yaml.Unmarshal(b, &cfg); err != nil {
+		return nil, fmt.Errorf("parse config: %w", err)
+	}
+	seen := map[string]bool{}
+	for i := range cfg.Mirrors {
+		m := &cfg.Mirrors[i]
+		if m.Owner == "" || m.Name == "" || m.CloneAddr == "" {
+			return nil, fmt.Errorf("entry %d: owner, name and clone_addr are required", i)
+		}
+		key := m.Owner + "/" + m.Name
+		if seen[key] {
+			return nil, fmt.Errorf("duplicate mirror %s", key)
+		}
+		seen[key] = true
+	}
+	return &cfg, nil
+}
+
+func env(key, def string) string {
+	if v := os.Getenv(key); v != "" {
+		return v
+	}
+	return def
+}
+
+func main() {
+	if err := run(); err != nil {
+		fmt.Fprintf(os.Stderr, "gitea-mirror-sync: %v\n", err)
+		os.Exit(1)
+	}
+}
+
+func run() error {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
+	defer cancel()
+
+	mirrorsFile := env("MIRRORS_FILE", "/etc/mirrors/mirrors.yaml")
+	dryRun := os.Getenv("DRY_RUN") == "true"
+	prune := os.Getenv("PRUNE")
+	if prune == "" {
+		prune = "true"
+	}
+	shouldPrune := prune == "true"
+
+	cfg, err := loadConfig(mirrorsFile)
+	if err != nil {
+		return err
+	}
+	fmt.Printf("loaded %d mirror(s) from %s\n", len(cfg.Mirrors), mirrorsFile)
+
+	c := newClient(env("GITEA_URL", ""), os.Getenv("GITEA_USER"), os.Getenv("GITEA_PASS"))
+
+	// Reconcile desired state.
+	desired := map[string]bool{}
+	for _, m := range cfg.Mirrors {
+		key := m.Owner + "/" + m.Name
+		desired[key] = true
+
+		r, err := c.getRepo(ctx, m.Owner, m.Name)
+		if err != nil {
+			return fmt.Errorf("checking %s: %w", key, err)
+		}
+		switch {
+		case r == nil:
+			fmt.Printf("create mirror %s <- %s\n", key, m.CloneAddr)
+			if !dryRun {
+				if err := c.migrate(ctx, m); err != nil {
+					return err
+				}
+			}
+		case !r.Mirror:
+			fmt.Printf("error: %s exists but is not a mirror; refusing to convert it\n", key)
+			continue
+		default:
+			if m.MirrorInterval != "" || r.Private != m.Private {
+				fmt.Printf("update mirror %s (mirror_interval=%s private=%v)\n", key, m.MirrorInterval, m.Private)
+				if !dryRun {
+					if err := c.updateRepo(ctx, r, m); err != nil {
+						return err
+					}
+				}
+			} else {
+				fmt.Printf("ok mirror %s\n", key)
+			}
+		}
+	}
+
+	// Prune mirrors in any managed owner that are no longer desired.
+	if !shouldPrune {
+		fmt.Println("prune disabled; skipping cleanup")
+		return nil
+	}
+	owners := map[string]bool{}
+	for _, m := range cfg.Mirrors {
+		owners[m.Owner] = true
+	}
+	for owner := range owners {
+		repos, err := c.listRepos(ctx, owner)
+		if err != nil {
+			return fmt.Errorf("listing repos for %s: %w", owner, err)
+		}
+		for _, r := range repos {
+			key := r.Owner.Name + "/" + r.Name
+			if !r.Mirror {
+				continue // never touch non-mirror repos
+			}
+			if desired[key] {
+				continue
+			}
+			fmt.Printf("prune mirror %s\n", key)
+			if !dryRun {
+				if err := c.deleteRepo(ctx, r.Owner.Name, r.Name); err != nil {
+					return err
+				}
+			}
+		}
+	}
+	return nil
+}

--- a/k8s-apps/gitea/Chart.yaml
+++ b/k8s-apps/gitea/Chart.yaml
@@ -14,7 +14,3 @@ dependencies:
   - name: valkey
     repository: https://valkey.io/valkey-helm/
     version: 0.10.0
-  - name: app-template
-    alias: gitea-mirror
-    repository: https://bjw-s-labs.github.io/helm-charts
-    version: 5.0.1

--- a/k8s-apps/gitea/templates/mirror-sync.yaml
+++ b/k8s-apps/gitea/templates/mirror-sync.yaml
@@ -1,0 +1,70 @@
+{{- if .Values.mirrorSync.enabled }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ .Release.Name }}-mirror-sync
+  labels:
+    app.kubernetes.io/managed-by: {{ .Release.Name }}
+  annotations:
+    argocd.argoproj.io/sync-options: ServerSideApply=true
+data:
+  mirrors.yaml: |
+{{- toYaml (dict "mirrors" .Values.mirrorSync.mirrors) | nindent 4 }}
+---
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: {{ .Release.Name }}-mirror-sync
+  labels:
+    app.kubernetes.io/managed-by: {{ .Release.Name }}
+  annotations:
+    argocd.argoproj.io/sync-options: ServerSideApply=true
+spec:
+  schedule: {{ .Values.mirrorSync.schedule | quote }}
+  concurrencyPolicy: Forbid
+  successfulJobsHistoryLimit: 1
+  failedJobsHistoryLimit: 1
+  jobTemplate:
+    spec:
+      backoffLimit: 2
+      ttlSecondsAfterFinished: 86400
+      template:
+        metadata:
+          labels:
+            app.kubernetes.io/managed-by: {{ .Release.Name }}-mirror-sync
+        spec:
+          restartPolicy: Never
+          automountServiceAccountToken: false
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 65532
+            runAsGroup: 65532
+            fsGroupChangePolicy: OnRootMismatch
+          containers:
+            - name: sync
+              image: "{{ .Values.mirrorSync.image.registry }}/{{ .Values.mirrorSync.image.repository }}:{{ .Values.mirrorSync.image.tag }}"
+              imagePullPolicy: IfNotPresent
+              env:
+                - name: GITEA_URL
+                  value: {{ .Values.mirrorSync.giteaURL | quote }}
+                - name: GITEA_USER
+                  valueFrom:
+                    secretKeyRef:
+                      name: gitea-admin-credentials
+                      key: username
+                - name: GITEA_PASS
+                  valueFrom:
+                    secretKeyRef:
+                      name: gitea-admin-credentials
+                      key: password
+                - name: PRUNE
+                  value: {{ .Values.mirrorSync.prune | quote }}
+              volumeMounts:
+                - name: mirrors
+                  mountPath: /etc/mirrors
+                  readOnly: true
+          volumes:
+            - name: mirrors
+              configMap:
+                name: {{ .Release.Name }}-mirror-sync
+{{- end }}

--- a/k8s-apps/gitea/values.yaml
+++ b/k8s-apps/gitea/values.yaml
@@ -596,130 +596,24 @@ valkey:
       helm.sh/resource-policy: keep
       argocd.argoproj.io/sync-options: Delete=false
 
-gitea-mirror:
-  global:
-    nameOverride: gitea-mirror
-    fullnameOverride: gitea-mirror
-    labels:
-      app.kubernetes.io/instance: gitea-mirror
-      app.kubernetes.io/name: gitea-mirror
-  defaultPodOptions:
-    automountServiceAccountToken: false
-    securityContext:
-      runAsUser: 568
-      runAsGroup: 568
-      fsGroup: 568
-      fsGroupChangePolicy: "OnRootMismatch"
 
-  configMaps:
-    config:
-      data:
-        NODE_ENV: production
-        DATABASE_URL: file:data/gitea-mirror.db
-        HOST: "0.0.0.0"
-        PORT: "4321"
-        BETTER_AUTH_URL: https://gitm.terence.cloud
-        BETTER_AUTH_TRUSTED_ORIGINS: http://localhost:4321
-  controllers:
-    main:
-      type: deployment
-      strategy: Recreate
-      annotations:
-        reloader.stakater.com/auto: "true"
-      containers:
-        main:
-          image:
-            repository: ghcr.io/raylabshq/gitea-mirror
-            tag: v3.21.0@sha256:ef101da58f0e8d4e1eab96e37ef8f90cf756a8c6d68ab977f8ce7e4b69cb1318
-          env:
-            TZ: Europe/Paris
-            BETTER_AUTH_SECRET:
-              valueFrom:
-                secretKeyRef:
-                  name: "{{ .Release.Name }}-better-auth-secret"
-                  key: password
-          envFrom:
-            - configMapRef:
-                identifier: config
-          ports:
-            - name: http
-              containerPort: 4321
-          probes:
-            liveness:
-              enabled: true
-              custom: true
-              spec:
-                httpGet:
-                  port: http
-                  path: /api/health
-            readiness:
-              enabled: true
-              custom: true
-              spec:
-                httpGet:
-                  port: http
-                  path: /api/health
-
-  service:
-    main:
-      controller: main
-      type: ClusterIP
-      ports:
-        http:
-          port: 4321
-
-  ingress:
-    main:
-      annotations:
-        cert-manager.io/cluster-issuer: letsencrypt
-        external-dns.alpha.kubernetes.io/target: home.terence.cloud
-        external-dns.alpha.kubernetes.io/cloudflare-proxied: "false"
-        traefik.ingress.kubernetes.io/router.tls.options: cert-manager-client-auth@kubernetescrd
-        traefik.ingress.kubernetes.io/router.middlewares: traefik-modsecurity@kubernetescrd
-      className: "traefik"
-      hosts:
-        - host: &host gitm.terence.cloud
-          paths:
-            - path: /
-              pathType: Prefix
-              service:
-                identifier: main
-                port: http
-      tls:
-        - secretName: gitea-mirror-tls
-          hosts:
-            - *host
-
-  persistence:
-    data:
-      enabled: true
-      type: persistentVolumeClaim
-      annotations:
-        helm.sh/resource-policy: keep
-        argocd.argoproj.io/sync-options: Delete=false
-      accessMode: ReadWriteOnce
-      size: 500Mi
-      globalMounts:
-        - path: /app/data
-
-  rawResources:
-    better-auth-secret:
-      enabled: true
-      forceRename: "{{ .Release.Name }}-better-auth-secret"
-      manifest:
-        apiVersion: external-secrets.io/v1
-        kind: ExternalSecret
-        metadata:
-          annotations:
-            argocd.argoproj.io/sync-options: ServerSideApply=true
-        spec:
-          refreshInterval: "0"
-          target:
-            name: "{{ .Release.Name }}-better-auth-secret"
-            creationPolicy: Owner
-          dataFrom:
-            - sourceRef:
-                generatorRef:
-                  apiVersion: generators.external-secrets.io/v1alpha1
-                  kind: ClusterGenerator
-                  name: password
+mirrorSync:
+  enabled: true
+  # Internal gitea HTTP service. With release name "gitea" the chart
+  # exposes <release>-http.<namespace>.svc:3000.
+  giteaURL: http://gitea-http.gitea.svc.cluster.local:3000
+  schedule: "0 */6 * * *"
+  prune: "true"
+  image:
+    registry: registry.registry:5000
+    repository: gitea-mirror-sync
+    tag: v1
+  # Declarative list of mirrors gitea should keep in sync. Add/remove entries
+  # here; the reconciler creates missing mirrors, updates settings on existing
+  # ones, and prunes mirrors in the same owner that are no longer listed.
+  mirrors:
+    - owner: terence
+      name: homelab-gitops
+      clone_addr: https://github.com/cterence/homelab-gitops.git
+      mirror_interval: 8h
+      private: false

--- a/k8s-apps/go-healthcheck/values.yaml
+++ b/k8s-apps/go-healthcheck/values.yaml
@@ -10,7 +10,6 @@ urls:
   - https://jf.terence.cloud/health
   - https://jstat.terence.cloud/auth/isconfigured
   - https://git.terence.cloud/api/healthz
-  - https://gitm.terence.cloud/api/health
   - https://lid.terence.cloud/ping
   - https://next.terence.cloud/status.php
   - https://niks3.terence.cloud/health


### PR DESCRIPTION
The `raylabshq/gitea-mirror` web app (deployment, ingress, PVC, auth secret) was overkill for the goal of keeping a declarative list of repos mirrored into gitea. This replaces it with a lightweight GitOps reconciler.

## What changed

**New Go CLI: `image-builds/gitea-mirror-sync/`**
- Reads a YAML list of desired mirrors and reconciles them against gitea's API.
- Creates missing mirrors via `/repos/migrate` with `mirror: true`.
- Patches `mirror_interval`/`private` on existing mirrors when they drift.
- Prunes mirrors in managed owners that are no longer in the list (never touches non-mirror repos).
- Gitea then handles the periodic pulling natively — no external app needed.
- Built via the existing Kaniko `image-builds` ApplicationSet to `registry.registry:5000/gitea-mirror-sync:v1`.

**gitea chart (`k8s-apps/gitea/`)**
- New `templates/mirror-sync.yaml`: a ConfigMap holding `mirrors.yaml` + a CronJob running the reconciler every 6h.
- New `mirrorSync` values section — the `mirrors` list is the single source of truth. Edit `values.yaml` to add/remove mirrors.
- Credentials come from the existing `gitea-admin-credentials` secret (basic auth against the gitea API).
- Dropped the `app-template`/`gitea-mirror` subchart, its `gitm.terence.cloud` ingress, PVC, and the `better-auth-secret` ExternalSecret.

**go-healthcheck**
- Removed the now-defunct `https://gitm.terence.cloud/api/health` URL.

## Verification
- `go vet` and `go build` pass for the Go program.
- Reconciler logic exercised against a mock gitea API server: create, update (drift), and prune paths all behave correctly; non-mirror repos are left untouched.
- `helm dependency update`, `helm lint`, and `helm template` all succeed for the gitea chart; no traces of the old subchart remain in the rendered output.

## Notes / assumptions
- The gitea admin password has no 2FA, so basic auth works against the API. If 2FA is ever enabled, switch to an API token.
- The image must be built first: after merge, the `image-builds` ApplicationSet will render a Kaniko Job for `gitea-mirror-sync:v1`. The CronJob will fail to pull the image until that build completes.
- Pruning only deletes mirrors whose owners appear in the YAML, so manually-created mirrors in other owners are safe.

Generated by Mistral Vibe.
Co-Authored-By: Mistral Vibe <vibe@mistral.ai>