### PR TITLE
registry: expose via registry.terence.cloud TLS ingress

### DIFF
--- a/image-builds/README.md
+++ b/image-builds/README.md
@@ -22,7 +22,18 @@ rebuild.
 
 ## Consuming an image
 
-Reference it in any app: `registry.registry:5000/<image>:<tag>`.
+The registry is exposed externally at `registry.terence.cloud` (TLS via
+cert-manager/Letsencrypt, routed through traefik). Reference any built image
+from any app or node:
+
+```
+registry.terence.cloud/<image>:<tag>
+```
+
+Nodes resolve `registry.terence.cloud` via public DNS and trust the
+Letsencrypt certificate, so no insecure-registry containerd config is needed.
+Kaniko pushes in-cluster via `registry.registry:5000` (the service DNS
+resolves from within the cluster); pulls go through the external TLS ingress.
 
 ## Prerequisite: repository must be public
 
@@ -31,12 +42,9 @@ Builds rely on Kaniko performing an anonymous `git` clone of this repository
 public. If it is made private, a git credential secret must be mounted into the
 Kaniko Job.
 
-## Prerequisite: insecure registry for pulls
+## Prerequisite: insecure registry for pushes
 
-The registry is plain HTTP. Kaniko pushes with `--insecure`. For nodes to
-**pull** these images, each node's container runtime must treat
-`registry.registry:5000` as an insecure registry. Configure containerd's
-registry hosts (e.g. `/etc/containerd/certs.d/registry.registry:5000/hosts.toml`
-with `skip_verify = true` / `http`) or the equivalent for your runtime. If you
-prefer not to touch node config, switch the registry to TLS instead (out of
-scope for this iteration).
+The registry service is plain HTTP. Kaniko pushes with `--insecure` to the
+in-cluster service `registry.registry:5000`. Pulls go through the external
+TLS ingress (`registry.terence.cloud`), so nodes do not need any insecure
+registry configuration.

--- a/k8s-apps/gitea/values.yaml
+++ b/k8s-apps/gitea/values.yaml
@@ -605,7 +605,7 @@ mirrorSync:
   schedule: "0 */6 * * *"
   prune: "true"
   image:
-    registry: registry.registry:5000
+    registry: registry.terence.cloud
     repository: gitea-mirror-sync
     tag: v1
   # Declarative list of mirrors gitea should keep in sync. Add/remove entries

--- a/k8s-apps/registry/values.yaml
+++ b/k8s-apps/registry/values.yaml
@@ -51,6 +51,26 @@ app-template:
         http:
           port: 5000
 
+  ingress:
+    main:
+      annotations:
+        cert-manager.io/cluster-issuer: letsencrypt
+        external-dns.alpha.kubernetes.io/target: home.terence.cloud
+        external-dns.alpha.kubernetes.io/cloudflare-proxied: "false"
+      className: "traefik"
+      hosts:
+        - host: &host registry.terence.cloud
+          paths:
+            - path: /
+              pathType: Prefix
+              service:
+                identifier: main
+                port: http
+      tls:
+        - secretName: registry-tls
+          hosts:
+            - *host
+
   persistence:
     data:
       enabled: true


### PR DESCRIPTION
The registry ingress commit from PR #695 was dropped during squash-merge. This recreates it.

## Why

Nodes use host DNS for image pulls, so the in-cluster service DNS (`registry.registry:5000` / `*.svc.cluster.local`) is not resolvable from kubelet/containerd. This made built images unpullable — the `gitea-mirror-sync` CronJob failed with `lookup registry.registry: no such host`.

## Changes

- **registry**: add TLS ingress on `registry.terence.cloud` (cert-manager/Letsencrypt, traefik). Nodes resolve the public domain and trust the cert — no insecure-registry containerd config needed on nodes.
- **gitea**: CronJob pulls `registry.terence.cloud/gitea-mirror-sync:v1` (Kaniko still pushes in-cluster to `registry.registry:5000`, which resolves fine from inside the cluster).
- **image-builds/README**: document the external pull domain and drop the stale insecure-pull prerequisite.

## Verification
- `helm lint` and `helm template` pass for both registry and gitea charts.
- Ingress renders correctly with TLS on `registry.terence.cloud`.
- CronJob image reference renders as `registry.terence.cloud/gitea-mirror-sync:v1`.

## Note
No auth on the registry yet — anyone who can reach `home.terence.cloud` can pull and push. Worth adding htpasswd or an IP allowlist in a follow-up.

Generated by Mistral Vibe.
Co-Authored-By: Mistral Vibe <vibe@mistral.ai>