### PR TITLE
gitea-mirror-sync: default owner/name/interval from URL

### DIFF
--- a/image-builds/gitea-mirror-sync/build.yaml
+++ b/image-builds/gitea-mirror-sync/build.yaml
@@ -1,2 +1,2 @@
 image: gitea-mirror-sync
-tag: v1
+tag: v2

--- a/image-builds/gitea-mirror-sync/main.go
+++ b/image-builds/gitea-mirror-sync/main.go
@@ -20,17 +20,21 @@ import (
 
 // Config is the YAML document mounted into the reconciler.
 type Config struct {
-	Mirrors []Mirror `yaml:"mirrors"`
+	DefaultOwner          string   `yaml:"defaultOwner"`
+	DefaultMirrorInterval string   `yaml:"defaultMirrorInterval"`
+	Mirrors               []Mirror `yaml:"mirrors"`
 }
 
-// Mirror is a single desired mirror entry.
+// Mirror is a single desired mirror entry. Only CloneAddr is required;
+// Owner, Name and the rest fall back to Config defaults or are derived
+// from the clone URL.
 type Mirror struct {
-	Owner          string `yaml:"owner"          json:"owner"`
-	Name           string `yaml:"name"           json:"name"`
-	CloneAddr      string `yaml:"clone_addr"     json:"clone_addr"`
+	Owner          string `yaml:"owner"           json:"owner"`
+	Name           string `yaml:"name"            json:"name"`
+	CloneAddr      string `yaml:"clone_addr"      json:"clone_addr"`
 	MirrorInterval string `yaml:"mirror_interval" json:"mirror_interval,omitempty"`
-	Private        bool   `yaml:"private"        json:"private"`
-	Wiki           bool   `yaml:"wiki"           json:"wiki"`
+	Private        bool   `yaml:"private"          json:"private"`
+	Wiki           bool   `yaml:"wiki"            json:"wiki"`
 }
 
 // repo is the subset of Gitea's repository response that we use.
@@ -202,6 +206,29 @@ func bodyText(resp *http.Response) string {
 	return resp.Status + ": " + string(b)
 }
 
+// repoNameFromURL derives a mirror name from a clone URL by taking the last
+// path segment and stripping a trailing ".git". For example
+// "https://github.com/cterence/homelab-gitops.git" -> "homelab-gitops".
+// It falls back to the raw host/path if the URL cannot be parsed.
+func repoNameFromURL(cloneAddr string) (string, error) {
+	u, err := url.Parse(cloneAddr)
+	if err != nil {
+		return "", fmt.Errorf("parse clone_addr %q: %w", cloneAddr, err)
+	}
+	p := strings.Trim(u.Path, "/")
+	p = strings.TrimSuffix(p, ".git")
+	p = strings.Trim(p, "/")
+	if p == "" {
+		return "", fmt.Errorf("could not derive repo name from %q", cloneAddr)
+	}
+	// A scp-like "host:owner/repo" shorthand has no scheme and parses as path;
+	// take the last segment either way.
+	if i := strings.LastIndex(p, "/"); i >= 0 {
+		p = p[i+1:]
+	}
+	return p, nil
+}
+
 func loadConfig(path string) (*Config, error) {
 	b, err := os.ReadFile(path)
 	if err != nil {
@@ -211,11 +238,30 @@ func loadConfig(path string) (*Config, error) {
 	if err := yaml.Unmarshal(b, &cfg); err != nil {
 		return nil, fmt.Errorf("parse config: %w", err)
 	}
+	if cfg.DefaultMirrorInterval == "" {
+		cfg.DefaultMirrorInterval = "8h"
+	}
 	seen := map[string]bool{}
 	for i := range cfg.Mirrors {
 		m := &cfg.Mirrors[i]
-		if m.Owner == "" || m.Name == "" || m.CloneAddr == "" {
-			return nil, fmt.Errorf("entry %d: owner, name and clone_addr are required", i)
+		if m.CloneAddr == "" {
+			return nil, fmt.Errorf("entry %d: clone_addr is required", i)
+		}
+		if m.Name == "" {
+			name, err := repoNameFromURL(m.CloneAddr)
+			if err != nil {
+				return nil, fmt.Errorf("entry %d: %w", i, err)
+			}
+			m.Name = name
+		}
+		if m.Owner == "" {
+			if cfg.DefaultOwner == "" {
+				return nil, fmt.Errorf("entry %d: owner is required (set defaultOwner or owner)", i)
+			}
+			m.Owner = cfg.DefaultOwner
+		}
+		if m.MirrorInterval == "" {
+			m.MirrorInterval = cfg.DefaultMirrorInterval
 		}
 		key := m.Owner + "/" + m.Name
 		if seen[key] {

--- a/k8s-apps/gitea/templates/mirror-sync.yaml
+++ b/k8s-apps/gitea/templates/mirror-sync.yaml
@@ -9,7 +9,10 @@ metadata:
     argocd.argoproj.io/sync-options: ServerSideApply=true
 data:
   mirrors.yaml: |
-{{- toYaml (dict "mirrors" .Values.mirrorSync.mirrors) | nindent 4 }}
+{{- $cfg := dict "mirrors" .Values.mirrorSync.mirrors -}}
+{{- if .Values.mirrorSync.defaultOwner -}}{{- $_ := set $cfg "defaultOwner" .Values.mirrorSync.defaultOwner -}}{{- end -}}
+{{- if .Values.mirrorSync.defaultMirrorInterval -}}{{- $_ := set $cfg "defaultMirrorInterval" .Values.mirrorSync.defaultMirrorInterval -}}{{- end -}}
+{{- toYaml $cfg | nindent 4 }}
 ---
 apiVersion: batch/v1
 kind: CronJob

--- a/k8s-apps/gitea/values.yaml
+++ b/k8s-apps/gitea/values.yaml
@@ -604,10 +604,10 @@ mirrorSync:
   image:
     registry: registry.terence.cloud
     repository: gitea-mirror-sync
-    tag: v1
+    tag: v2
+  # Declarative list of mirrors gitea should keep in sync. Only clone_addr is
+  # required; name is derived from the URL, owner falls back to defaultOwner,
+  # and mirror_interval defaults to 8h. Override any field per-entry as needed.
+  defaultOwner: terence
   mirrors:
-    - owner: terence
-      name: homelab-gitops
-      clone_addr: https://github.com/cterence/homelab-gitops.git
-      mirror_interval: 8h
-      private: false
+    - clone_addr: https://github.com/cterence/homelab-gitops.git


### PR DESCRIPTION
Only `clone_addr` is now required per mirror entry. The rest is derived or defaulted:

- **name**: derived from the clone URL's last path segment (strips `.git`). e.g. `https://github.com/cterence/homelab-gitops.git` → `homelab-gitops`
- **owner**: falls back to top-level `defaultOwner`
- **mirror_interval**: defaults to `8h`
- **private** / **wiki**: default to `false`

Override any field per-entry as needed.

## Example

```yaml
defaultOwner: terence
mirrors:
  - clone_addr: https://github.com/cterence/homelab-gitops.git
  - clone_addr: https://github.com/kubernetes/kubernetes.git
    owner: upstreams
    mirror_interval: 24h
```

## Changes
- `main.go`: added `Config.DefaultOwner`/`DefaultMirrorInterval`, `repoNameFromURL` helper, defaults applied in `loadConfig`
- `k8s-apps/gitea/values.yaml`: simplified `mirrors` list with `defaultOwner: terence`
- `k8s-apps/gitea/templates/mirror-sync.yaml`: render `defaultOwner` into the ConfigMap
- `image-builds/gitea-mirror-sync/build.yaml`: tag v2 (triggers rebuild)

## Verification
- `go vet` + `go build` pass
- Smoke-tested with a 2-entry config (one using defaults, one overriding owner+interval): both resolve to the expected owner/name/interval
- `helm lint` + `helm template` pass; ConfigMap renders `defaultOwner` and the simplified entry correctly

Generated by Mistral Vibe.
Co-Authored-By: Mistral Vibe <vibe@mistral.ai>